### PR TITLE
Fix TUI exit code on component failure

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -184,10 +184,17 @@ func runCommand(args []string) {
 	} else if len(cfg.Sources) > 0 && cfg.Sources[0].PollInterval.Duration > 0 {
 		tuiOpts = append(tuiOpts, tui.WithPollInterval(cfg.Sources[0].PollInterval.Duration))
 	}
-	tuiOpts = append(tuiOpts, tui.WithShutdown(shutdownFn))
+	var shutdownErr error
+	tuiOpts = append(tuiOpts, tui.WithShutdown(func() error {
+		shutdownErr = shutdownFn()
+		return shutdownErr
+	}))
 	model := tui.NewModel(runtime, tuiOpts...)
 	if _, err := tea.NewProgram(model, tea.WithAltScreen()).Run(); err != nil {
 		fatalf("run tui: %v", err)
+	}
+	if shutdownErr != nil {
+		fatalf("run service: %v", shutdownErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- In TUI mode, component shutdown errors (runtime crash, API bind failure) were silently swallowed — process always exited 0
- Now captures the shutdown error and exits non-zero via `fatalf`
- Headless mode (`--no-tui`) was already correct

Addresses the P1 from Codex review on #3.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go build` — compiles cleanly