### PR TITLE
Allow SCP-style SSH URLs in repo config

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -262,6 +262,10 @@ func validateRepoURL(raw string) error {
 	if raw == "" {
 		return nil
 	}
+	// Accept SCP-style SSH URLs (e.g. git@host:org/repo.git).
+	if isScpStyleURL(raw) {
+		return nil
+	}
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("invalid repo url %q: %w", raw, err)
@@ -270,6 +274,12 @@ func validateRepoURL(raw string) error {
 		return fmt.Errorf("repo urls must not embed credentials; use connection.token_env instead")
 	}
 	return nil
+}
+
+// isScpStyleURL returns true for SCP-style git SSH URLs like git@host:org/repo.git.
+func isScpStyleURL(raw string) bool {
+	// Must contain a colon but no scheme (://). The colon separates host from path.
+	return strings.Contains(raw, ":") && !strings.Contains(raw, "://")
 }
 
 func requiresSourceRepo(workspace string, tracker string) bool {


### PR DESCRIPTION
## Summary

- `validateRepoURL()` passes URLs through `url.Parse()`, which rejects SCP-style SSH URLs (`git@host:org/repo.git`) because the colon is invalid in the first path segment
- Add `isScpStyleURL()` to detect and accept this standard git URL format before falling through to `url.Parse()`

## Test plan

- [ ] Existing config tests pass (`go test ./internal/config/...`)
- [ ] Manual: set `repo: git@host:org/repo.git` in config — validation should pass