### PR TITLE
Support source-level stall_timeout override

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -209,6 +209,9 @@ func mergeSourceDefaults(target *SourceConfig, defaults SourceDefaultsEntry) {
 	if target.PollInterval.Duration == 0 {
 		target.PollInterval = defaults.PollInterval
 	}
+	if target.StallTimeout.Duration == 0 {
+		target.StallTimeout = defaults.StallTimeout
+	}
 	if target.RetryBase.Duration == 0 {
 		target.RetryBase = defaults.RetryBase
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -217,6 +217,7 @@ type SourceDefaultsEntry struct {
 	AgentType       string           `yaml:"agent_type"`
 	MaxActiveRuns   int              `yaml:"max_active_runs"`
 	PollInterval    Duration         `yaml:"poll_interval"`
+	StallTimeout    Duration         `yaml:"stall_timeout"`
 	RetryBase       Duration         `yaml:"retry_base"`
 	MaxRetryBackoff Duration         `yaml:"max_retry_backoff"`
 	MaxAttempts     int              `yaml:"max_attempts"`
@@ -265,6 +266,7 @@ type SourceConfig struct {
 	MaxRetryBackoff Duration             `yaml:"max_retry_backoff"`
 	MaxAttempts     int                  `yaml:"max_attempts"`
 	RespectBlockers *bool                `yaml:"respect_blockers"`
+	StallTimeout    Duration             `yaml:"stall_timeout"`
 	OnDispatch      *DispatchTransition  `yaml:"on_dispatch"`
 	OnComplete      *LifecycleTransition `yaml:"on_complete"`
 	OnFailure       *LifecycleTransition `yaml:"on_failure"`
@@ -387,6 +389,13 @@ func (s SourceConfig) EffectiveMaxAttempts(state StateConfig) int {
 		return s.MaxAttempts
 	}
 	return state.MaxAttempts
+}
+
+func (s SourceConfig) EffectiveStallTimeout(agent AgentTypeConfig) time.Duration {
+	if s.StallTimeout.Duration > 0 {
+		return s.StallTimeout.Duration
+	}
+	return agent.StallTimeout.Duration
 }
 
 func (s SourceConfig) EffectiveRespectBlockers() bool {

--- a/internal/orchestrator/stall.go
+++ b/internal/orchestrator/stall.go
@@ -20,10 +20,11 @@ func (s *Service) reconcileStalledRun(ctx context.Context) {
 		if run.LastActivityAt.IsZero() {
 			continue
 		}
-		if time.Since(run.LastActivityAt) < s.agent.StallTimeout.Duration {
+		stallTimeout := s.source.EffectiveStallTimeout(s.agent)
+		if time.Since(run.LastActivityAt) < stallTimeout {
 			continue
 		}
-		s.stopRunAsFailed(ctx, run.ID, fmt.Sprintf("run stalled after %s without observable activity", s.agent.StallTimeout.Duration))
+		s.stopRunAsFailed(ctx, run.ID, fmt.Sprintf("run stalled after %s without observable activity", stallTimeout))
 	}
 }
 

--- a/internal/orchestrator/stall_test.go
+++ b/internal/orchestrator/stall_test.go
@@ -76,6 +76,28 @@ func TestReconcileStalledRunIgnoresNonStallStatuses(t *testing.T) {
 	}
 }
 
+func TestReconcileStalledRunRespectsSourceOverride(t *testing.T) {
+	fakeHarness := &testutil.FakeHarness{}
+	svc := newStallTestService(fakeHarness, 50*time.Millisecond)
+	// Source sets a longer stall timeout that should override the agent default.
+	svc.source.StallTimeout = config.Duration{Duration: time.Hour}
+	svc.activeRun = &domain.AgentRun{
+		ID:             "run-1",
+		SourceName:     "test-source",
+		Status:         domain.RunStatusActive,
+		LastActivityAt: time.Now().Add(-time.Second),
+	}
+
+	svc.reconcileStalledRun(context.Background())
+
+	if len(fakeHarness.StopCalls) != 0 {
+		t.Fatalf("stop calls = %+v, want none (source stall_timeout should keep run alive)", fakeHarness.StopCalls)
+	}
+	if len(svc.pendingStops) != 0 {
+		t.Fatalf("pending stops = %+v, want none", svc.pendingStops)
+	}
+}
+
 func newStallTestService(fakeHarness *testutil.FakeHarness, stallTimeout time.Duration) *Service {
 	return &Service{
 		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),


### PR DESCRIPTION
## Summary

- Add `stall_timeout` field to `SourceConfig` and `SourceDefaultsEntry` so sources can override the agent-type default
- Add `EffectiveStallTimeout()` method that prefers the source-level value, falling back to the agent type
- Update the stall detector to use `EffectiveStallTimeout()` instead of reading directly from the agent config
- Wire `stall_timeout` through `mergeSourceDefaults` for source-defaults propagation

Previously, setting `stall_timeout` on a source was silently ignored because `SourceConfig` had no such field. The YAML values were discarded and all sources inherited the agent-type default (typically 10m). This broke long-running workflows like ES upgrades that need hours-long stall windows.

## Test plan

- [x] New test `TestReconcileStalledRunRespectsSourceOverride` — verifies a source-level stall timeout prevents premature stall kills
- [x] All existing stall tests pass unchanged
- [x] Full `go test ./...` passes